### PR TITLE
fix: fixed download pandoc version

### DIFF
--- a/download.js
+++ b/download.js
@@ -36,7 +36,8 @@ async function extractAsset(zipPath, downloadDir) {
 }
 
 async function run() {
-  const { body: release } = await got('https://api.github.com/repos/jgm/pandoc/releases/latest', { json: true });
+  const VERSION = '3.1.11'
+  const { body: release } = await got(`https://api.github.com/repos/jgm/pandoc/releases/tags/${VERSION}`, { json: true });
   const donwloadRoot = path.join(__dirname, './.pandoc-local');
   const downloadDir = path.join(donwloadRoot, release.tag_name);
 


### PR DESCRIPTION
Hi @Yukaii 

According to [this security advisory](https://github.com/jgm/pandoc/security/advisories/GHSA-xj5q-fv23-575g), we need to update the Pandoc version.

Although `download.js` uses the latest release, it freezes the version when the user installs it. Therefore, we might consider fixing the Pandoc version. Each time we update the Pandoc version, we should also bump `@hackmd/pandoc.js`. This way, when users update their dependencies, it will trigger a reinstallation.

What do you think? Thanks!
